### PR TITLE
Create docker-compose.quickstart.yml

### DIFF
--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -5,5 +5,9 @@ services:
     image: davestephens/enigma-bbs
     ports:
       - "8888:8888"
-    restart_policy:
+    deploy:
+      restart_policy:
         condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 120s

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+
+  bbs:
+    image: davestephens/enigma-bbs
+    ports:
+      - "8888:8888"
+    restart_policy:
+        condition: on-failure


### PR DESCRIPTION
Created a simple quickstart Docker Compose file. This is good to include so new users can simply type in `docker compose -f docker-compose.quickstart.yml up` and immediately have the basic container running.