### PR TITLE
Added link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Docker container that runs [ENiGMA½ BBS Software](https://github.com/NuSkooler/enigma-bbs). All required packages for 
 ENiGMA½ to run successfully are included, and pm2-docker is used to manage the Node.js process.
 
+Docker Hub: [https://hub.docker.com/r/davestephens/enigma-bbs](https://hub.docker.com/r/davestephens/enigma-bbs)
+
 ## Quick Start
 
 This container image is available from the Docker Hub.


### PR DESCRIPTION
It can be frustrating sometimes to track down Docker Hub repos from GitLab/GitHub repos and be assured it's the same project. Embedding a link to the Docker Hub project directly into the README.md ensures that users who come across this repo will be able to easily find it.